### PR TITLE
Fix: replace deprecated output definition

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -17,7 +17,7 @@ jobs:
       - id: create-ref
         run: |
           TAG_REF=$(echo $GITHUB_REF | cut -d / -f 3)
-          echo "::set-output name=tag-ref::TAG_REF"
+          echo "tag-ref=$TAG_REF" >> $GITHUB_OUTPUT
     outputs:
       tag-ref: ${{ steps.create-ref.outputs.tag-ref }}
 


### PR DESCRIPTION
## What does this pull request change?
The `set-output` command in the GitHub Actions workflows, [is about to become deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

## Why is this pull request needed?
To change from the 
```sh
echo "::set-output name=tag-ref::TAG_REF"
```
to the new
```sh
echo "tag-ref=$TAG_REF" >> $GITHUB_OUTPUT
```
stanza

## Issues related to this change

