### PR TITLE
Refactor: remove `uiRecipes` definition from blueprints

### DIFF
--- a/app/data/WorkflowDS/Blueprints/AzureContainer.json
+++ b/app/data/WorkflowDS/Blueprints/AzureContainer.json
@@ -2,6 +2,6 @@
   "type": "CORE:Blueprint",
   "name": "AzureContainer",
   "description": "Description of a executable job running as an Azure Container Instance",
-  "extends": ["/Container", "/JobHandler"],
+  "extends": ["Container", "JobHandler"],
   "attributes": []
 }

--- a/app/data/WorkflowDS/Blueprints/AzureContainer.json
+++ b/app/data/WorkflowDS/Blueprints/AzureContainer.json
@@ -2,6 +2,6 @@
   "type": "CORE:Blueprint",
   "name": "AzureContainer",
   "description": "Description of a executable job running as an Azure Container Instance",
-  "extends": ["CORE:DefaultUiRecipes", "/Container", "/JobHandler"],
+  "extends": ["/Container", "/JobHandler"],
   "attributes": []
 }

--- a/app/data/WorkflowDS/Blueprints/Container.json
+++ b/app/data/WorkflowDS/Blueprints/Container.json
@@ -2,10 +2,7 @@
   "type": "CORE:Blueprint",
   "name": "Container",
   "description": "A container job",
-  "extends": [
-    "CORE:DefaultUiRecipes",
-    "/JobHandler"
-  ],
+  "extends": ["/JobHandler"],
   "attributes": [
     {
       "attributeType": "string",
@@ -23,15 +20,6 @@
       "type": "CORE:BlueprintAttribute",
       "name": "customCommand",
       "optional": true
-    }
-  ],
-  "uiRecipes": [
-    {
-      "name": "Edit",
-      "type": "CORE:UiRecipe",
-      "plugin": "edit-container-job",
-      "configType": "",
-      "category": "edit"
     }
   ]
 }

--- a/app/data/WorkflowDS/Blueprints/Container.json
+++ b/app/data/WorkflowDS/Blueprints/Container.json
@@ -2,7 +2,7 @@
   "type": "CORE:Blueprint",
   "name": "Container",
   "description": "A container job",
-  "extends": ["/JobHandler"],
+  "extends": ["JobHandler"],
   "attributes": [
     {
       "attributeType": "string",

--- a/app/data/WorkflowDS/Blueprints/ContainerImage.json
+++ b/app/data/WorkflowDS/Blueprints/ContainerImage.json
@@ -1,9 +1,6 @@
 {
   "name": "ContainerImage",
   "type": "CORE:Blueprint",
-  "extends": [
-    "CORE:DefaultUiRecipes"
-  ],
   "description": "Container image used as job runner for a task. Full container image name is name/subName",
   "attributes": [
       {
@@ -39,6 +36,5 @@
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string"
     }
-  ],
-  "uiRecipes": []
+  ]
 }

--- a/app/data/WorkflowDS/Blueprints/CronJob.json
+++ b/app/data/WorkflowDS/Blueprints/CronJob.json
@@ -2,7 +2,7 @@
   "type": "CORE:Blueprint",
   "name": "CronJob",
   "description": "Blueprint for a job triggered by a time schedule",
-  "extends": ["CORE:DefaultUiRecipes", "CORE:NamedEntity"],
+  "extends": ["CORE:NamedEntity"],
   "attributes": [
     {
       "attributeType": "string",

--- a/app/data/WorkflowDS/Blueprints/Job.json
+++ b/app/data/WorkflowDS/Blueprints/Job.json
@@ -2,7 +2,6 @@
     "name": "Job",
     "abstract": true,
     "type": "CORE:Blueprint",
-    "extends": ["CORE:DefaultUiRecipes"],
     "attributes": [
       {
         "name": "uid",
@@ -78,22 +77,6 @@
         "label": "Reference target",
         "description": "Dotted id to an analysis entity's job result. Should be on the format: entityId.jobs.*index*.result. Must be generated at run time since the index can vary.",
         "optional": true
-      }
-    ],
-    "uiRecipes": [
-      {
-        "name": "Edit",
-        "type": "CORE:UiRecipe",
-        "plugin": "jobInputEdit",
-        "category": "edit",
-        "roles": ["dmss-admin", "domain-expert", "expert-operator", "operator"]
-      },
-      {
-        "name": "Control pane",
-        "type": "CORE:UiRecipe",
-        "plugin": "jobControl",
-        "category": "view",
-        "roles": ["dmss-admin", "domain-expert", "expert-operator", "operator"]
       }
     ]
   }

--- a/app/data/WorkflowDS/Blueprints/JobHandler.json
+++ b/app/data/WorkflowDS/Blueprints/JobHandler.json
@@ -3,7 +3,7 @@
   "name": "JobHandler",
   "description": "Base jobHandler type. Other jobHandlers should extend from this one",
   "attributes": [
-{
+    {
       "attributeType": "string",
       "type": "CORE:BlueprintAttribute",
       "name": "environmentVariables",

--- a/app/data/WorkflowDS/Blueprints/ReverseDescription.json
+++ b/app/data/WorkflowDS/Blueprints/ReverseDescription.json
@@ -1,6 +1,6 @@
 {
   "type": "CORE:Blueprint",
   "name": "ReverseDescription",
-  "extends": ["/JobHandler"],
+  "extends": ["JobHandler"],
   "description": "A job that takes an input of any type, and outputs a copy with the description reversed"
 }

--- a/app/data/WorkflowDS/Blueprints/ReverseDescription.json
+++ b/app/data/WorkflowDS/Blueprints/ReverseDescription.json
@@ -1,19 +1,6 @@
 {
   "type": "CORE:Blueprint",
   "name": "ReverseDescription",
-  "extends": [
-    "/JobHandler",
-    "CORE:DefaultUiRecipes"
-  ],
-  "description": "A job that takes an input of any type, and outputs a copy with the description reversed",
-
-  "uiRecipes": [
-    {
-      "name": "Edit",
-      "type": "CORE:UiRecipe",
-      "plugin": "edit-reverse-description",
-      "configType": "",
-      "category": "edit"
-    }
-  ]
+  "extends": ["/JobHandler"],
+  "description": "A job that takes an input of any type, and outputs a copy with the description reversed"
 }

--- a/app/data/WorkflowDS/Blueprints/Shell.json
+++ b/app/data/WorkflowDS/Blueprints/Shell.json
@@ -3,7 +3,7 @@
   "name": "Shell",
   "extends": [
     "CORE:NamedEntity",
-    "/JobHandler"
+    "JobHandler"
   ],
   "description": "Description of a shell-job. That is a job that will run in the shell. Only for testing.",
   "attributes": [

--- a/app/data/WorkflowDS/Blueprints/Shell.json
+++ b/app/data/WorkflowDS/Blueprints/Shell.json
@@ -2,7 +2,6 @@
   "type": "CORE:Blueprint",
   "name": "Shell",
   "extends": [
-    "CORE:DefaultUiRecipes",
     "CORE:NamedEntity",
     "/JobHandler"
   ],


### PR DESCRIPTION
## What does this pull request change?
Removes the `uiRecipes` definition from blueprints

## Why is this pull request needed?

## Issues related to this change

