### PR TITLE
ci: lock dmss version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   dmss:
-    image: datamodelingtool.azurecr.io/dmss:latest
+    image: datamodelingtool.azurecr.io/dmss:v1.3.0
     restart: unless-stopped
     environment:
       ENVIRONMENT: local


### PR DESCRIPTION
## What does this pull request change?

Lock dmss image to 1.3.0

## Why is this pull request needed?

## Issues related to this change

