### PR TITLE
fix: reduce resolution depth to 1 to handle cycles in references

### DIFF
--- a/src/services/job_service.py
+++ b/src/services/job_service.py
@@ -120,7 +120,7 @@ class JobService:
         """
         protocol, data_source_id, job_entity_id, attribute = split_address(dmss_id)
         return get_document_by_uid(
-            reference=f"{data_source_id}/{job_entity_id}.{attribute}", token=token, depth=50, resolve_links=False
+            reference=f"{data_source_id}/{job_entity_id}.{attribute}", token=token, depth=1, resolve_links=False
         )
 
     @staticmethod


### PR DESCRIPTION
## What does this pull request change?
Stops cyclic resolutions of reference links from going on uncontrolled.

## Why is this pull request needed?
A Job applicationInput points to its parent Case, which creates a cycle. 

## Issues related to this change

