### PR TITLE
build: stop using virtual venv inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 FROM python:3.10-slim as base
-ENV PYTHONUNBUFFERED=1 PYTHONPATH=/code/src
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/code/src
 WORKDIR /code
-ENTRYPOINT ["/code/src/init.sh"]
-CMD ["api"]
+CMD ["/code/src/init.sh", "api"]
 EXPOSE 5000
 
 RUN apt-get update -y && apt-get full-upgrade -y && apt-get install -y curl
 
-ENV PATH="/code/.venv/bin:$PATH"
-
 RUN pip install --upgrade pip && \
     pip install poetry && \
-    poetry config virtualenvs.in-project true
+    poetry config virtualenvs.create false
 
 COPY pyproject.toml poetry.lock ./
 
@@ -21,7 +19,6 @@ WORKDIR /code/src
 COPY src /code/src/
 COPY app /code/app/
 COPY .flake8 .bandit ./
-CMD ["api"]
 
 
 FROM base as prod
@@ -30,4 +27,3 @@ WORKDIR /code/src
 COPY src /code/src/
 COPY app /code/app/
 USER 1000
-CMD ["api"]


### PR DESCRIPTION
## What does this pull request change?

* Stop using virtual venv inside docker

## Why is this pull request needed?

## Issues related to this change

