### PR TITLE
fix: include application input in job payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ typings/
 .env
 scripts/reset-db.env
 
+# asdf
+.tool-versions
+
 # next.js build output
 .next
 

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -24,7 +24,7 @@ class JobHandler(JobHandlerInterface):
     def start(self) -> str:
         logger.info("Starting Radix job...")
         # Add token and URL to payload, so that jobs are able to connect to the DMSS instance.
-        payload = {"DMSS_TOKEN": self.job.token, "DMSS_URL": config.DMSS_API}
+        payload = {"DMSS_TOKEN": self.job.token, "DMSS_URL": config.DMSS_API, "DMSS_ID": self.job.dmss_id}
         result = requests.post(
             _get_job_url(self.job),
             json={"payload": json.dumps(payload)},

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -29,6 +29,7 @@ class Job:
         cron_job: bool = False,
         token: str | None = None,
         state: dict | None = None,
+        application_input: dict | None = None,
     ):
         self.dmss_id: str = dmss_id
         self.job_uid: UUID = job_uid
@@ -40,6 +41,7 @@ class Job:
         self.cron_job: bool = cron_job
         self.token: str | None = token
         self.state = state
+        self.application_input = application_input
 
     def update_entity_attributes(self):
         # These attributes are common amongst all Job entities
@@ -60,6 +62,7 @@ class Job:
             "cron_job": self.cron_job,
             "token": self.token,
             "state": self.state,
+            "applicationInput": self.application_input,
         }
 
     @classmethod
@@ -75,6 +78,7 @@ class Job:
             cron_job=a_dict.get("cron_job", False),
             token=a_dict.get("token"),
             state=a_dict.get("state", None),
+            application_input=a_dict.get("applicationInput", None),
         )
 
 


### PR DESCRIPTION
## What does this pull request change?
Pass the job application input to the job instance in radix via the payload file

## Why is this pull request needed?
The radix job handler plugin only passes the DMSS_TOKEN and DMSS_URL to the job instance, but the application input is also needed to run calculations.

## Issues related to this change

