### PR TITLE
fix: make radix job handler return status code instead of calling status

### DIFF
--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -35,7 +35,8 @@ class JobHandler(JobHandlerInterface):
         # so that we can call the job scheduler
         # to get the progress or to remove the job.
         self.job.state = {"job_name": result.json()["name"]}
-        return result.status()  # type: ignore
+        logger.info(f"result:  {result}")
+        return result.status_code  # type: ignore
 
     def remove(self) -> Tuple[str, str]:
         result = requests.delete(


### PR DESCRIPTION
## What does this pull request change?
Response does not have a "status" attribute, so we change it to "status_code" which is correct

## Why is this pull request needed?
Job fails when it tries to call response.status()

## Issues related to this change

