### PR TITLE
fix: move dmss variables into environment variables in runner entity

### DIFF
--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -49,8 +49,10 @@ class JobHandler(JobHandlerInterface):
         envs = [f"{e}={os.getenv(e)}" for e in config.SCHEDULER_ENVS_TO_EXPORT if os.getenv(e)]
 
         custom_command = self.job.entity["runner"].get("customCommands")
-
+        envs = envs + runner_entity["environmentVariables"]
         envs.append(f"DMSS_TOKEN={self.job.token}")
+        envs.append(f"DMSS_ID={self.job.dmss_id}")
+        envs.append(f"DMSS_URL={config.DMSS_API}")
         self.client.containers.run(
             image=full_image_name,
             command=custom_command,


### PR DESCRIPTION
## What does this pull request change?
moves dmss information needed to run local job out of local file and into environmentVariables in the runner entity

## Why is this pull request needed?

## Issues related to this change

