### PR TITLE
fix: implement environmentVariables radix job handler

### DIFF
--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -17,9 +17,7 @@ def _get_job_url(job: Job) -> str:
 
 
 def list_of_env_to_dict(env_vars) -> dict:
-    keys = [s.split("=")[0] for s in env_vars]
-    values = [s.split("=")[1] for s in env_vars]
-    return dict(zip(keys, values))
+    return {s.split("=")[0]: s.split("=")[1] for s in env_vars}
 
 
 class JobHandler(JobHandlerInterface):


### PR DESCRIPTION
## What does this pull request change?
Make the radix job handler use environment variables from job runner entity defined in the WorkflowDS/JobHandler blueprint.

## Why is this pull request needed?
Gives the flexibility to define env variables for radix jobs in the job runner entity.

## Issues related to this change

