### PR TITLE
fix: add local docker network name to container runner

### DIFF
--- a/app/data/WorkflowDS/Blueprints/Container.json
+++ b/app/data/WorkflowDS/Blueprints/Container.json
@@ -28,6 +28,11 @@
       "name": "name",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string"
+    },
+    {
+      "name": "network",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
     }
   ]
 }

--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -53,7 +53,7 @@ class JobHandler(JobHandlerInterface):
             command=custom_command,
             name=self.local_container_name,
             environment=envs,
-            network="application_default",
+            network=self.job.runner["network"],
             detach=True,
         )
         logger.info("*** Local container job started successfully ***")


### PR DESCRIPTION
## What does this pull request change?
Gives the possibility to define the name of which container network to append the new job containers to

## Why is this pull request needed?
Postpone setting of the network name parameter to runtime for flexibility

## Issues related to this change

