### PR TITLE
fix: make environment variables optional for local container runner

### DIFF
--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -44,7 +44,7 @@ class JobHandler(JobHandlerInterface):
         envs = [f"{e}={os.getenv(e)}" for e in config.SCHEDULER_ENVS_TO_EXPORT if os.getenv(e)]
 
         custom_command = self.job.runner.get("customCommands")
-        envs = envs + runner_entity["environmentVariables"]
+        envs = envs + runner_entity.get("environmentVariables", [])
         envs.append(f"DMSS_TOKEN={self.job.token}")
         envs.append(f"DMSS_ID={self.job.dmss_id}")
         envs.append(f"DMSS_URL={config.DMSS_API}")


### PR DESCRIPTION
## What does this pull request change?
Environment variables are optional according to the JobHandler blueprint, so the job handler should take this into account when injecting them into the job.

## Why is this pull request needed?

## Issues related to this change

