### PR TITLE
fix: remove abstract from job blueprint

### DIFF
--- a/app/data/WorkflowDS/Blueprints/Job.json
+++ b/app/data/WorkflowDS/Blueprints/Job.json
@@ -1,7 +1,6 @@
 {
   "name": "Job",
   "type": "CORE:Blueprint",
-  "abstract": true,
   "attributes": [
     {
       "name": "type",


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?
Support for abstract was removed in dmss.

## Issues related to this change

