### PR TITLE
fix: add separate blueprint for local container runner

### DIFF
--- a/app/data/WorkflowDS/Blueprints/AzureContainer.json
+++ b/app/data/WorkflowDS/Blueprints/AzureContainer.json
@@ -3,8 +3,7 @@
   "type": "CORE:Blueprint",
   "description": "Description of a executable job running as an Azure Container Instance",
   "extends": [
-    "Container",
-    "JobHandler"
+    "Container"
   ],
   "attributes": []
 }

--- a/app/data/WorkflowDS/Blueprints/Container.json
+++ b/app/data/WorkflowDS/Blueprints/Container.json
@@ -28,11 +28,6 @@
       "name": "name",
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string"
-    },
-    {
-      "name": "network",
-      "type": "CORE:BlueprintAttribute",
-      "attributeType": "string"
     }
   ]
 }

--- a/app/data/WorkflowDS/Blueprints/LocalContainer.json
+++ b/app/data/WorkflowDS/Blueprints/LocalContainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "LocalContainer",
+  "type": "CORE:Blueprint",
+  "description": "Description of a executable job running as a Container in a local Docker network",
+  "extends": [
+    "Container"
+  ],
+  "attributes": [
+    {
+      "name": "network",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -8,7 +8,7 @@ from config import config
 from services.job_handler_interface import Job, JobHandlerInterface, JobStatus
 from utils.logging import logger
 
-_SUPPORTED_TYPE = "dmss://WorkflowDS/Blueprints/Container"
+_SUPPORTED_TYPE = "dmss://WorkflowDS/Blueprints/LocalContainer"
 
 
 class JobHandler(JobHandlerInterface):


### PR DESCRIPTION
## What does this pull request change?
Adds a blueprint for local container runner

## Why is this pull request needed?
Running jobs in containers locally needs a network name, which azure container runner does not

## Issues related to this change

