### PR TITLE
Fix/radix job handler progress

### DIFF
--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -29,7 +29,7 @@ class JobHandler(JobHandlerInterface):
         logger.info("Starting Radix job...")
         # Add token and URL to payload, so that jobs are able to connect to the DMSS instance.
         try:
-            payload = list_of_env_to_dict(self.job.runner["environmentVariables"])
+            payload = list_of_env_to_dict(self.job.runner.get("environmentVariables", []))
         except IndexError:
             raise ValueError(
                 f"Malformed environment variable received by job handler of type {_SUPPORTED_TYPE}. Should be on the format <key>=<value> (location: {self.job.dmss_id})"
@@ -59,6 +59,8 @@ class JobHandler(JobHandlerInterface):
         return JobStatus.REMOVED, "Removed"
 
     def progress(self) -> Tuple[JobStatus, str]:
+        if not self.job.state:
+            return self.job.status, self.job.log
         result = requests.get(
             f"{_get_job_url(self.job)}/{self.job.state['job_name']}",
             timeout=10,

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -68,11 +68,15 @@ class JobHandler(JobHandlerInterface):
         result.raise_for_status()
         response_json = result.json()
         job_status = JobStatus.UNKNOWN
+        job_log = "No logs available yet!"
         match (response_json["status"]):  # noqa
             case "Running":  # noqa
                 job_status = JobStatus.RUNNING
+                job_log = json.dumps(response_json)
             case "Failed":  # noqa
                 job_status = JobStatus.FAILED
+                job_log = json.dumps(response_json)
             case "Succeeded":  # noqa
                 job_status = JobStatus.COMPLETED
-        return job_status, response_json["message"]
+                job_log = json.dumps(response_json)
+        return job_status, job_log


### PR DESCRIPTION
## What does this pull request change?
Make the api return the entire radix response when radix job handler progress is invoked

## Why is this pull request needed?
Gives more information about the status of the job during polling from the JobPlugin

## Issues related to this change

