### PR TITLE
fix: radix job handler return radix response as log

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class JobHandler(JobHandlerInterface):
         """Terminate and cleanup all job related resources"""
         raise NotImplementedError
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         """Poll progress from the job instance"""
         raise NotImplementedError
 

--- a/src/default_job_handlers/local_shell/__init__.py
+++ b/src/default_job_handlers/local_shell/__init__.py
@@ -48,6 +48,6 @@ class JobHandler(JobHandlerInterface):
             pass
         return "Local shell job removed"
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         """Poll progress from the job instance"""
-        return JobStatus.UNKNOWN, "Shell jobs does not support progress polling"
+        return JobStatus.UNKNOWN, "Shell jobs does not support progress polling", None

--- a/src/default_job_handlers/shell_script/__init__.py
+++ b/src/default_job_handlers/shell_script/__init__.py
@@ -47,6 +47,6 @@ class JobHandler(JobHandlerInterface):
             pass
         return "Local shell job removed"
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         """Poll progress from the job instance"""
-        return JobStatus.UNKNOWN, "Shell jobs does not support progress polling"
+        return JobStatus.UNKNOWN, None, "Shell jobs does not support progress polling"

--- a/src/job_handler_plugins/azure_container_instances/__init__.py
+++ b/src/job_handler_plugins/azure_container_instances/__init__.py
@@ -131,11 +131,11 @@ class JobHandler(JobHandlerInterface):
             job_status = JobStatus.COMPLETED
         return job_status, status
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         """Poll progress from the job instance"""
         if self.job.status == JobStatus.FAILED:
             # If setup fails, the container is not started
-            return self.job.status, self.job.log
+            return self.job.status, self.job.log, None
         try:
             logger.setLevel(logging.WARNING)
             logs = self.aci_client.containers.list_logs(
@@ -171,4 +171,4 @@ class JobHandler(JobHandlerInterface):
                 job_status = JobStatus.FAILED
             case ("Waiting", None):  # noqa
                 job_status = JobStatus.STARTING
-        return job_status, logs
+        return job_status, logs, None

--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -67,11 +67,11 @@ class JobHandler(JobHandlerInterface):
             pass
         return JobStatus.REMOVED, "Removed"
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         """Poll progress from the job instance"""
         if self.job.status == JobStatus.FAILED:
             # If setup fails, the container is not started
-            return self.job.status, self.job.log
+            return self.job.status, self.job.log, None
         try:
             container = self.client.containers.get(self.local_container_name)
             status = self.job.status
@@ -82,10 +82,10 @@ class JobHandler(JobHandlerInterface):
             elif container.attrs["State"]["ExitCode"] == 0:
                 status = JobStatus.COMPLETED
             logs = container.logs()
-            return status, logs.decode()
+            return status, logs.decode(), None
         except docker.errors.NotFound as error:
             logger.error(f"Failed to poll progress of local container: {error}")
-            return JobStatus.UNKNOWN, self.job.log
+            return JobStatus.UNKNOWN, self.job.log, None
 
     def result(self) -> Tuple[str, bytes]:
         return "test 123", b"lkjgfdakljhfdgsllkjhldafgoiu8y03q987hgbloizdjhfpg980"

--- a/src/job_handler_plugins/omnia_classic_azure_container_instances/__init__.py
+++ b/src/job_handler_plugins/omnia_classic_azure_container_instances/__init__.py
@@ -123,7 +123,7 @@ class JobHandler(JobHandlerInterface):
             job_status = JobStatus.COMPLETED
         return job_status, status
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         """Poll progress from the job instance"""
         try:
             logger.setLevel(logging.WARNING)
@@ -151,4 +151,4 @@ class JobHandler(JobHandlerInterface):
             job_status = JobStatus.COMPLETED
         if status == "Waiting":
             job_status = JobStatus.STARTING
-        return job_status, logs
+        return job_status, logs, None

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -58,9 +58,9 @@ class JobHandler(JobHandlerInterface):
         result.raise_for_status()
         return JobStatus.REMOVED, "Removed"
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         if not self.job.state:
-            return self.job.status, self.job.log
+            return self.job.status, None, "Job is not yet started"
         result = requests.get(
             f"{_get_job_url(self.job)}/{self.job.state['job_name']}",
             timeout=10,
@@ -68,15 +68,15 @@ class JobHandler(JobHandlerInterface):
         result.raise_for_status()
         response_json = result.json()
         job_status = JobStatus.UNKNOWN
-        job_log = "No logs available yet!"
+        message = "No logs available yet!"
         match (response_json["status"]):  # noqa
             case "Running":  # noqa
                 job_status = JobStatus.RUNNING
-                job_log = json.dumps(response_json)
+                message = json.dumps(response_json)
             case "Failed":  # noqa
                 job_status = JobStatus.FAILED
-                job_log = json.dumps(response_json)
+                message = json.dumps(response_json)
             case "Succeeded":  # noqa
                 job_status = JobStatus.COMPLETED
-                job_log = json.dumps(response_json)
-        return job_status, job_log
+                message = json.dumps(response_json)
+        return job_status, None, message

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -46,7 +46,7 @@ class JobHandler(JobHandlerInterface):
         # Need to store the unique job name in the state,
         # so that we can call the job scheduler
         # to get the progress or to remove the job.
-        self.job.state = {"job_name": result.json()["name"]}
+        self.job.state = {"job_name": result.json()["name"], "prev_status": self.job.status}
         logger.info(f"result:  {result}")
         return result.status_code  # type: ignore
 
@@ -79,4 +79,7 @@ class JobHandler(JobHandlerInterface):
             case "Succeeded":  # noqa
                 job_status = JobStatus.COMPLETED
                 job_log = json.dumps(response_json)
+        if self.job.state["prev_status"] != job_status:
+            job_log = f"{self.job.log}\n{job_log}"
+            self.job.state["prev_status"] = job_status
         return job_status, job_log

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -17,7 +17,7 @@ def _get_job_url(job: Job) -> str:
 
 
 def list_of_env_to_dict(env_vars) -> dict:
-    return {s.split("=")[0]: s.split("=")[1] for s in env_vars}
+    return {s.lsplit("=", 1)[0]: s.lsplit("=", 1)[1] for s in env_vars}
 
 
 class JobHandler(JobHandlerInterface):
@@ -46,7 +46,7 @@ class JobHandler(JobHandlerInterface):
         # Need to store the unique job name in the state,
         # so that we can call the job scheduler
         # to get the progress or to remove the job.
-        self.job.state = {"job_name": result.json()["name"], "prev_status": self.job.status}
+        self.job.state = {"job_name": result.json()["name"]}
         logger.info(f"result:  {result}")
         return result.status_code  # type: ignore
 
@@ -79,7 +79,4 @@ class JobHandler(JobHandlerInterface):
             case "Succeeded":  # noqa
                 job_status = JobStatus.COMPLETED
                 job_log = json.dumps(response_json)
-        if self.job.state["prev_status"] != job_status:
-            job_log = f"{self.job.log}\n{job_log}"
-            self.job.state["prev_status"] = job_status
         return job_status, job_log

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -68,11 +68,15 @@ class JobHandler(JobHandlerInterface):
         result.raise_for_status()
         response_json = result.json()
         job_status = JobStatus.UNKNOWN
+        job_log = "No logs available yet!"
         match (response_json["status"]):  # noqa
             case "Running":  # noqa
                 job_status = JobStatus.RUNNING
+                job_log = json.dumps(response_json)
             case "Failed":  # noqa
                 job_status = JobStatus.FAILED
+                job_log = json.dumps(response_json)
             case "Succeeded":  # noqa
                 job_status = JobStatus.COMPLETED
-        return job_status, response_json["message"]
+                job_log = json.dumps(response_json)
+        return job_status, job_log

--- a/src/job_handler_plugins/recurring_job/__init__.py
+++ b/src/job_handler_plugins/recurring_job/__init__.py
@@ -48,5 +48,5 @@ class JobHandler(JobHandlerInterface):
     def result(self) -> Tuple[str, bytes]:
         raise NotImplementedError
 
-    def progress(self) -> Tuple[JobStatus, str]:
-        return self.job.status, self.job.log
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
+        return self.job.status, self.job.log, None

--- a/src/job_handler_plugins/recurring_job/__init__.py
+++ b/src/job_handler_plugins/recurring_job/__init__.py
@@ -24,7 +24,7 @@ class JobHandler(JobHandlerInterface):
         self.headers = {"Access-Key": job.token or ""}
 
     def start(self) -> str:
-        msg = f'{self.job.log}\nStarting scheduled job from "{self.job.dmss_id}"'
+        msg = f'Starting scheduled job from "{self.job.dmss_id}"'
         logger.info(msg)
         self.job.append_log(msg)
 
@@ -35,7 +35,7 @@ class JobHandler(JobHandlerInterface):
 
         new_uid, new_log = register_job(complete_new_job_address)
 
-        msg = f'{self.job.log}\nJob: "{new_uid}", Status: "{new_log}"'
+        msg = f'Job: "{new_uid}", Status: "{new_log}"'
         logger.info(msg)
         self.job.append_log(msg)
         self.job.status = JobStatus.RUNNING

--- a/src/job_handler_plugins/recurring_job/__init__.py
+++ b/src/job_handler_plugins/recurring_job/__init__.py
@@ -26,7 +26,7 @@ class JobHandler(JobHandlerInterface):
     def start(self) -> str:
         msg = f'{self.job.log}\nStarting scheduled job from "{self.job.dmss_id}"'
         logger.info(msg)
-        self.job.log = f"{self.job.log}\n{msg}"
+        self.job.append_log(msg)
 
         job_template = self.job.application_input
         new_job_address = add_document(f"{self.job.dmss_id}.schedule.runs", job_template, self.job.token)
@@ -37,7 +37,7 @@ class JobHandler(JobHandlerInterface):
 
         msg = f'{self.job.log}\nJob: "{new_uid}", Status: "{new_log}"'
         logger.info(msg)
-        self.job.log = f"{self.job.log}\n{msg}"
+        self.job.append_log(msg)
         self.job.status = JobStatus.RUNNING
         return "OK"
 

--- a/src/job_handler_plugins/reverse_description/__init__.py
+++ b/src/job_handler_plugins/reverse_description/__init__.py
@@ -46,5 +46,5 @@ class JobHandler(JobHandlerInterface):
         with open(result_file_path, "rb") as result_file:
             return "Done", result_file.read()
 
-    def progress(self) -> Tuple[JobStatus, str]:
-        return self.job.status, "Progress tracking not implemented"
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
+        return self.job.status, None, "Progress tracking not implemented"

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -63,8 +63,8 @@ class Job(BaseModel):
             setattr(self, field, value)
 
     def append_log(self, log):
-        new = f"\n{log}" if (self.log and log) else log
-        self.log = self.log + new if self.log else new
+        if log:
+            self.log = self.log + f"\n{log}" if self.log else log
 
 
 class JobHandlerInterface(ABC):
@@ -80,7 +80,7 @@ class JobHandlerInterface(ABC):
         """Terminate and cleanup all job related resources"""
         raise NotImplementedError
 
-    def progress(self) -> Tuple[JobStatus, str]:
+    def progress(self) -> Tuple[JobStatus, None | str, None | str]:
         """Poll progress from the job instance"""
         raise NotImplementedError
 

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -62,6 +62,9 @@ class Job(BaseModel):
         for field, value in merged_kwargs.items():
             setattr(self, field, value)
 
+    def append_log(self, log):
+        self.log = f"{self.log}\n{log}"
+
 
 class JobHandlerInterface(ABC):
     def __init__(self, job: Job, data_source: str):

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -63,7 +63,8 @@ class Job(BaseModel):
             setattr(self, field, value)
 
     def append_log(self, log):
-        self.log = f"{self.log}\n{log}"
+        new = f"\n{log}" if (self.log and log) else log
+        self.log = self.log + new if self.log else new
 
 
 class JobHandlerInterface(ABC):


### PR DESCRIPTION
make the api return the entire radix response when radix job handler progress is invoked

## What does this pull request change?

## Why is this pull request needed?

## Issues related to this change
Closes #115 

