### PR TITLE
fix: adjust when job status is set and save status removed to dmss

### DIFF
--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -12,6 +12,7 @@ from services.dmss import get_document
 
 class JobStatus(str, Enum):
     REGISTERED = "registered"
+    NOT_STARTED = "not started"
     STARTING = "starting"
     RUNNING = "running"
     FAILED = "failed"

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -12,7 +12,6 @@ from services.dmss import get_document
 
 class JobStatus(str, Enum):
     REGISTERED = "registered"
-    NOT_STARTED = "not started"
     STARTING = "starting"
     RUNNING = "running"
     FAILED = "failed"


### PR DESCRIPTION
## What does this pull request change?
- Set status of reccuring job to `REGISTERED` when it is scheduled but not yet run
- Set status of job to removed and update in dmss.

## Why is this pull request needed?
Updates some parts of how and when status of job is set

## Issues related to this change

