### PR TITLE
fix: force log flag in update progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class JobHandler(JobHandlerInterface):
         """Terminate and cleanup all job related resources"""
         raise NotImplementedError
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""
         raise NotImplementedError
 

--- a/src/default_job_handlers/local_shell/__init__.py
+++ b/src/default_job_handlers/local_shell/__init__.py
@@ -48,6 +48,6 @@ class JobHandler(JobHandlerInterface):
             pass
         return "Local shell job removed"
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""
-        return JobStatus.UNKNOWN, None, "Shell jobs does not support progress polling"
+        return JobStatus.UNKNOWN, ["Shell jobs does not support progress polling"], self.job.percentage

--- a/src/default_job_handlers/recurring_job/__init__.py
+++ b/src/default_job_handlers/recurring_job/__init__.py
@@ -48,5 +48,5 @@ class JobHandler(JobHandlerInterface):
     def result(self) -> Tuple[str, bytes]:
         raise NotImplementedError
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         return self.job.status, self.job.log, None

--- a/src/default_job_handlers/shell_script/__init__.py
+++ b/src/default_job_handlers/shell_script/__init__.py
@@ -47,6 +47,6 @@ class JobHandler(JobHandlerInterface):
             pass
         return "Local shell job removed"
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""
-        return JobStatus.UNKNOWN, None, "Shell jobs does not support progress polling"
+        return JobStatus.UNKNOWN, ["Shell jobs does not support progress polling"], self.job.percentage

--- a/src/features/jobs/jobs.py
+++ b/src/features/jobs/jobs.py
@@ -69,10 +69,10 @@ def result(job_uid: str):
 
 @router.put("/{job_uid}", operation_id="update_job_progress", response_model=UpdateJobProgressResponse)
 @create_response(JSONResponse)
-def progress(job_uid: str, job_progress: Progress):
+def progress(job_uid: str, overwrite_log: bool, job_progress: Progress):
     """Update the progress of the job.
 
     - **job_uid**: the job API's internal uid for the job.
     - **progress**: progress object with percentage and logs
     """
-    return update_job_progress_use_case(job_uid=job_uid, progress=job_progress).dict()
+    return update_job_progress_use_case(job_uid=job_uid, overwrite_log=overwrite_log, progress=job_progress).dict()

--- a/src/features/jobs/use_cases/status_job.py
+++ b/src/features/jobs/use_cases/status_job.py
@@ -8,13 +8,13 @@ from services.job_service import status_job
 
 class StatusJobResponse(BaseModel):
     status: JobStatus
-    log: list | None
-    message: str | None
+    log: list[str] | None
+    percentage: float | None
 
     class Config:
         use_enum_values = True
 
 
 def status_job_use_case(job_id: str) -> StatusJobResponse:
-    status, log, message = status_job(UUID(job_id))
-    return StatusJobResponse(**{"status": status.value, "log": log, "message": message})
+    status, log, percentage = status_job(UUID(job_id))
+    return StatusJobResponse(**{"status": status.value, "log": log, "percentage": percentage})

--- a/src/features/jobs/use_cases/update_job_progress.py
+++ b/src/features/jobs/use_cases/update_job_progress.py
@@ -10,6 +10,6 @@ class UpdateJobProgressResponse(BaseModel):
     result: str
 
 
-def update_job_progress_use_case(job_uid: str, progress: Progress) -> UpdateJobProgressResponse:
-    result = update_progress(UUID(job_uid), progress)
+def update_job_progress_use_case(job_uid: str, overwrite_log, progress: Progress) -> UpdateJobProgressResponse:
+    result = update_progress(UUID(job_uid), overwrite_log, progress)
     return UpdateJobProgressResponse(result=result)

--- a/src/job_handler_plugins/azure_container_instances/__init__.py
+++ b/src/job_handler_plugins/azure_container_instances/__init__.py
@@ -131,11 +131,11 @@ class JobHandler(JobHandlerInterface):
             job_status = JobStatus.COMPLETED
         return job_status, status
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""
         if self.job.status == JobStatus.FAILED:
             # If setup fails, the container is not started
-            return self.job.status, self.job.log, None
+            return self.job.status, self.job.log, self.job.percentage
         try:
             logger.setLevel(logging.WARNING)
             logs = self.aci_client.containers.list_logs(
@@ -171,4 +171,4 @@ class JobHandler(JobHandlerInterface):
                 job_status = JobStatus.FAILED
             case ("Waiting", None):  # noqa
                 job_status = JobStatus.STARTING
-        return job_status, logs, None
+        return job_status, logs, self.job.percentage

--- a/src/job_handler_plugins/omnia_classic_azure_container_instances/__init__.py
+++ b/src/job_handler_plugins/omnia_classic_azure_container_instances/__init__.py
@@ -123,7 +123,7 @@ class JobHandler(JobHandlerInterface):
             job_status = JobStatus.COMPLETED
         return job_status, status
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""
         try:
             logger.setLevel(logging.WARNING)
@@ -151,4 +151,4 @@ class JobHandler(JobHandlerInterface):
             job_status = JobStatus.COMPLETED
         if status == "Waiting":
             job_status = JobStatus.STARTING
-        return job_status, logs, None
+        return job_status, logs, self.job.percentage

--- a/src/job_handler_plugins/reverse_description/__init__.py
+++ b/src/job_handler_plugins/reverse_description/__init__.py
@@ -46,5 +46,5 @@ class JobHandler(JobHandlerInterface):
         with open(result_file_path, "rb") as result_file:
             return "Done", result_file.read()
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
-        return self.job.status, None, "Progress tracking not implemented"
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
+        return self.job.status, "Progress tracking not implemented", self.job.percentage

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -44,7 +44,7 @@ class Job(BaseModel):
     schedule: dict | None
 
     log: list | None = []
-    progress: float | None
+    percentage: float | None
     token: str | None
     state: dict | None
 
@@ -52,7 +52,7 @@ class Job(BaseModel):
     exclude_keys: dict = {
         "dmss_id": True,
         "log": True,
-        "progress": True,
+        "percentage": True,
         "token": True,
         "state": True,
         "exclude_keys": True,
@@ -70,9 +70,13 @@ class Job(BaseModel):
         for field, value in merged_kwargs.items():
             setattr(self, field, value)
 
-    def append_log(self, log):
-        if log:
-            self.log.append(log)
+    def append_log(self, log: list | str):
+        if not isinstance(log, list):
+            log = [f"JOBAPI: {log}"]
+        if self.log:
+            self.log.extend(log)
+        else:
+            self.log = log
 
 
 class JobHandlerInterface(ABC):
@@ -88,7 +92,7 @@ class JobHandlerInterface(ABC):
         """Terminate and cleanup all job related resources"""
         raise NotImplementedError
 
-    def progress(self) -> Tuple[JobStatus, None | list[str], None | str]:
+    def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""
         raise NotImplementedError
 


### PR DESCRIPTION
## What does this pull request change?
- Adds force_log flag to update progress endpoint. When false the posted logs are appended to existing logs. When true the posted logs directly overwrites existing logs.
- Replace messages returned from the job_status endpoint with progress percentage

## Why is this pull request needed?
Messages are single log lines that are returned but never stored. It is now possible to append messages to the logs instead

## Issues related to this change

