### PR TITLE
fix: add job api url to config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,7 @@ class Config:
     API_DEBUG = os.getenv("API_DEBUG", 0)
     ENVIRONMENT = os.getenv("ENVIRONMENT", "local")
     DMSS_API = os.getenv("DMSS_API", "http://dmss:5000")
+    JOB_API_URL = os.getenv("JOB_API_URL", "http://job-api:5000")
 
     # Azure stuff
     # Where to run jobs in Azure

--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -48,6 +48,7 @@ class JobHandler(JobHandlerInterface):
         envs.append(f"DMSS_TOKEN={self.job.token}")
         envs.append(f"DMSS_ID={self.job.dmss_id}")
         envs.append(f"DMSS_URL={config.DMSS_API}")
+        envs.append(f"JOB_API_URL={config.JOB_API_URL}")
         self.client.containers.run(
             image=full_image_name,
             command=custom_command,

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -36,6 +36,7 @@ class JobHandler(JobHandlerInterface):
             )
         payload["DMSS_TOKEN"] = self.job.token
         payload["DMSS_URL"] = config.DMSS_API
+        payload["JOB_API_URL"] = config.JOB_API_URL
         payload["DMSS_ID"] = self.job.dmss_id
         result = requests.post(
             _get_job_url(self.job),


### PR DESCRIPTION
## What does this pull request change?
Adds job api url to config so that it can be passed to the jobs for communication back to the job api

## Why is this pull request needed?
Allows jobs to use the job api by using a variable set at build time

## Issues related to this change

https://github.com/equinor/dm-app-simpos/pull/58