### PR TITLE
fix: kill docker container before remove

### DIFF
--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -62,11 +62,10 @@ class JobHandler(JobHandlerInterface):
         return message
 
     def remove(self) -> Tuple[str, str]:
-        try:
-            container = self.client.containers.get(self.local_container_name)
-            container.remove()
-        except docker.errors.NotFound:
-            pass
+        container = self.client.containers.get(self.local_container_name)
+        if container.status != "exited":
+            container.kill()
+        container.remove()
         return JobStatus.REMOVED, "Removed"
 
     def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:

--- a/src/services/job_service.py
+++ b/src/services/job_service.py
@@ -15,6 +15,7 @@ from redis import AuthenticationError
 from config import config
 from domain_classes.progress import Progress
 from restful.exceptions import (
+    ApplicationException,
     BadRequestException,
     NotFoundException,
     NotImplementedException,
@@ -253,6 +254,8 @@ def remove_job(job_uid: UUID) -> str:
     except NotImplementedError:
         job_status = JobStatus.REMOVED
         remove_message = "The job handler does not support the operation"
+    except Exception as err:
+        raise ApplicationException(data={"error": str(err)})
     job.status = job_status
     job.append_log(remove_message)
     update_document(job.dmss_id, job.json(by_alias=True, exclude_none=True, exclude=job.exclude_keys), job.token)


### PR DESCRIPTION
## What does this pull request change?
Stop the docker container before we remove it

## Why is this pull request needed?
Error is thrown if remove is called before it has exited

## Issues related to this change

