### PR TITLE
fix: return status from remove job and start job

### DIFF
--- a/src/default_job_handlers/recurring_job/__init__.py
+++ b/src/default_job_handlers/recurring_job/__init__.py
@@ -27,18 +27,17 @@ class JobHandler(JobHandlerInterface):
         msg = f'Starting scheduled job from "{self.job.dmss_id}"'
         logger.info(msg)
         self.job.append_log(msg)
-
         job_template = self.job.application_input
         new_job_address = add_document(f"{self.job.dmss_id}.schedule.runs", job_template, self.job.token)
         # TODO: Update DMSS to return complete address, and avoid this ugly stuff
         complete_new_job_address = self.job.dmss_id.split("$", 1)[0] + "$" + new_job_address["uid"]
 
-        new_uid, new_log = register_job(complete_new_job_address)
+        new_uid, new_log, status = register_job(complete_new_job_address)
 
-        msg = f'Job: "{new_uid}", Status: "{new_log}"'
+        msg = f'Job: "{new_uid}", Status: "{status}"'
         logger.info(msg)
         self.job.append_log(msg)
-        return "OK"
+        return msg
 
     def remove(self) -> str:
         """Terminate and cleanup all job related resources"""
@@ -48,4 +47,4 @@ class JobHandler(JobHandlerInterface):
         raise NotImplementedError
 
     def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
-        return self.job.status, self.job.log, None
+        return self.job.status, self.job.log, self.job.percentage

--- a/src/domain_classes/progress.py
+++ b/src/domain_classes/progress.py
@@ -5,5 +5,5 @@ from services.job_handler_interface import JobStatus
 
 class Progress(BaseModel):
     percentage: float | None
-    logs: list[str] | None
+    logs: list[str] | str | None
     status: JobStatus | None

--- a/src/features/jobs/jobs.py
+++ b/src/features/jobs/jobs.py
@@ -1,10 +1,10 @@
 from uuid import UUID
 
 from fastapi import APIRouter
-from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.responses import JSONResponse
 
 from domain_classes.progress import Progress
-from features.jobs.use_cases.delete_job import delete_job_use_case
+from features.jobs.use_cases.delete_job import DeleteJobResponse, delete_job_use_case
 from features.jobs.use_cases.get_result_job import (
     GetJobResultResponse,
     get_job_result_use_case,
@@ -48,15 +48,15 @@ def status(job_uid: UUID):
     return status_job_use_case(job_id=job_uid).dict()
 
 
-@router.delete("/{job_uid}", operation_id="remove_job")
-@create_response(PlainTextResponse)
+@router.delete("/{job_uid}", operation_id="remove_job", response_model=DeleteJobResponse)
+@create_response(JSONResponse)
 def remove(job_uid: UUID):
     """Remove an existing job by calling the remove() function in the job handler for a given job.
     The job will then be deleted from the redis database used for storing jobs.
 
     - **job_uid**: the job API's internal uid for the job.
     """
-    return delete_job_use_case(job_id=job_uid)
+    return delete_job_use_case(job_id=job_uid).dict()
 
 
 @router.get("/{job_uid}/result", operation_id="job_result", response_model=GetJobResultResponse)

--- a/src/features/jobs/use_cases/delete_job.py
+++ b/src/features/jobs/use_cases/delete_job.py
@@ -1,8 +1,16 @@
 from uuid import UUID
 
+from pydantic.main import BaseModel
+
+from services.job_handler_interface import JobStatus
 from services.job_service import remove_job
 
 
-def delete_job_use_case(job_id: UUID) -> str:
-    result: str = remove_job(job_id)
-    return result
+class DeleteJobResponse(BaseModel):
+    status: JobStatus
+    response: str
+
+
+def delete_job_use_case(job_id: UUID) -> DeleteJobResponse:
+    status, res = remove_job(job_id)
+    return DeleteJobResponse(status=status, response=res)

--- a/src/features/jobs/use_cases/get_result_job.py
+++ b/src/features/jobs/use_cases/get_result_job.py
@@ -12,4 +12,4 @@ class GetJobResultResponse(BaseModel):
 
 def get_job_result_use_case(job_uid: UUID) -> GetJobResultResponse:
     message, bytesvalue = get_job_result(job_uid)
-    return GetJobResultResponse(**{"message": message, "result": bytesvalue.decode("UTF-8")})
+    return GetJobResultResponse(message=message, result=bytesvalue)

--- a/src/features/jobs/use_cases/start_job.py
+++ b/src/features/jobs/use_cases/start_job.py
@@ -1,15 +1,15 @@
-from typing import Tuple
-
 from pydantic.main import BaseModel
 
+from services.job_handler_interface import JobStatus
 from services.job_service import register_job
 
 
 class StartJobResponse(BaseModel):
-    message: str
     uid: str
+    message: str
+    status: JobStatus
 
 
 def start_job_use_case(job_dmss_id: str) -> StartJobResponse:
-    result: Tuple[str, str] = register_job(job_dmss_id)
-    return StartJobResponse(**{"message": result[1], "uid": result[0]})
+    uid, message, status = register_job(job_dmss_id)
+    return StartJobResponse(uid=uid, message=message, status=status)

--- a/src/features/jobs/use_cases/status_job.py
+++ b/src/features/jobs/use_cases/status_job.py
@@ -17,4 +17,4 @@ class StatusJobResponse(BaseModel):
 
 def status_job_use_case(job_id: UUID) -> StatusJobResponse:
     status, log, percentage = status_job(job_id)
-    return StatusJobResponse(**{"status": status.value, "log": log, "percentage": percentage})
+    return StatusJobResponse(status=status, log=log, percentage=percentage)

--- a/src/features/jobs/use_cases/update_job_progress.py
+++ b/src/features/jobs/use_cases/update_job_progress.py
@@ -3,13 +3,13 @@ from uuid import UUID
 from pydantic.main import BaseModel
 
 from domain_classes.progress import Progress
-from services.job_service import update_progress
+from services.job_service import update_progress_from_uid
 
 
 class UpdateJobProgressResponse(BaseModel):
-    result: str
+    response: str
 
 
 def update_job_progress_use_case(job_uid: UUID, overwrite_log, progress: Progress) -> UpdateJobProgressResponse:
-    result = update_progress(job_uid, overwrite_log, progress)
-    return UpdateJobProgressResponse(result=result)
+    update_progress_from_uid(job_uid, progress, overwrite_log, True)
+    return UpdateJobProgressResponse(response="OK")

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -47,6 +47,7 @@ class Job(BaseModel):
     percentage: float | None
     token: str | None
     state: dict | None
+    external_progress: bool = False
 
     # Fields that are not sendt to DMSS
     exclude_keys: dict = {
@@ -55,12 +56,14 @@ class Job(BaseModel):
         "percentage": True,
         "token": True,
         "state": True,
+        "external_progress": True,
         "exclude_keys": True,
     }
 
     def append_log(self, log: list | str):
         if not isinstance(log, list):
-            log = [f"JOBAPI: {log}"]
+            logs = log.split("\n")
+            log = [f"JOBAPI: {log}" for log in logs]
         if self.log:
             self.log.extend(log)
         else:


### PR DESCRIPTION
## What does this pull request change?
Return status from job api when job is registered and stopped/deleted

## Why is this pull request needed?
Allows the frontend (job plugin) to change state based on responses from the api instead of guessing what has happended.

## Issues related to this change
PR in job plugin: https://github.com/equinor/dm-core-packages/pull/814
