### PR TITLE
fix: use UUID in the API

### DIFF
--- a/src/features/jobs/jobs.py
+++ b/src/features/jobs/jobs.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter
 from starlette.responses import JSONResponse, PlainTextResponse
 
@@ -38,7 +40,7 @@ def start(job_dmss_id: str):
 
 @router.get("/{job_uid}", operation_id="job_status", response_model=StatusJobResponse)
 @create_response(JSONResponse)
-def status(job_uid: str):
+def status(job_uid: UUID):
     """Get the status for an existing job.
 
     - **job_uid**: the job API's internal uid for the job.
@@ -48,7 +50,7 @@ def status(job_uid: str):
 
 @router.delete("/{job_uid}", operation_id="remove_job")
 @create_response(PlainTextResponse)
-def remove(job_uid: str):
+def remove(job_uid: UUID):
     """Remove an existing job by calling the remove() function in the job handler for a given job.
     The job will then be deleted from the redis database used for storing jobs.
 
@@ -59,7 +61,7 @@ def remove(job_uid: str):
 
 @router.get("/{job_uid}/result", operation_id="job_result", response_model=GetJobResultResponse)
 @create_response(JSONResponse)
-def result(job_uid: str):
+def result(job_uid: UUID):
     """Get the results from a completed job, by calling the result() function in the job handler for a given job.
 
     - **job_uid**: the job API's internal uid for the job.
@@ -69,7 +71,7 @@ def result(job_uid: str):
 
 @router.put("/{job_uid}", operation_id="update_job_progress", response_model=UpdateJobProgressResponse)
 @create_response(JSONResponse)
-def progress(job_uid: str, overwrite_log: bool, job_progress: Progress):
+def progress(job_uid: UUID, overwrite_log: bool, job_progress: Progress):
     """Update the progress of the job.
 
     - **job_uid**: the job API's internal uid for the job.

--- a/src/features/jobs/use_cases/delete_job.py
+++ b/src/features/jobs/use_cases/delete_job.py
@@ -3,6 +3,6 @@ from uuid import UUID
 from services.job_service import remove_job
 
 
-def delete_job_use_case(job_id: str) -> str:
-    result: str = remove_job(UUID(job_id))
+def delete_job_use_case(job_id: UUID) -> str:
+    result: str = remove_job(job_id)
     return result

--- a/src/features/jobs/use_cases/get_result_job.py
+++ b/src/features/jobs/use_cases/get_result_job.py
@@ -10,6 +10,6 @@ class GetJobResultResponse(BaseModel):
     result: str
 
 
-def get_job_result_use_case(job_uid: str) -> GetJobResultResponse:
-    message, bytesvalue = get_job_result(UUID(job_uid))
+def get_job_result_use_case(job_uid: UUID) -> GetJobResultResponse:
+    message, bytesvalue = get_job_result(job_uid)
     return GetJobResultResponse(**{"message": message, "result": bytesvalue.decode("UTF-8")})

--- a/src/features/jobs/use_cases/status_job.py
+++ b/src/features/jobs/use_cases/status_job.py
@@ -15,6 +15,6 @@ class StatusJobResponse(BaseModel):
         use_enum_values = True
 
 
-def status_job_use_case(job_id: str) -> StatusJobResponse:
-    status, log, percentage = status_job(UUID(job_id))
+def status_job_use_case(job_id: UUID) -> StatusJobResponse:
+    status, log, percentage = status_job(job_id)
     return StatusJobResponse(**{"status": status.value, "log": log, "percentage": percentage})

--- a/src/features/jobs/use_cases/update_job_progress.py
+++ b/src/features/jobs/use_cases/update_job_progress.py
@@ -10,6 +10,6 @@ class UpdateJobProgressResponse(BaseModel):
     result: str
 
 
-def update_job_progress_use_case(job_uid: str, overwrite_log, progress: Progress) -> UpdateJobProgressResponse:
-    result = update_progress(UUID(job_uid), overwrite_log, progress)
+def update_job_progress_use_case(job_uid: UUID, overwrite_log, progress: Progress) -> UpdateJobProgressResponse:
+    result = update_progress(job_uid, overwrite_log, progress)
     return UpdateJobProgressResponse(result=result)


### PR DESCRIPTION
## What does this pull request change?
Require UUID as API parameter type

## Why is this pull request needed?
Avoids 500 server error, returns 422 unprocessable_entity instead if the query param is not a valid UUIDv4

## Issues related to this change

