### PR TITLE
fix: change returned type from remove endpoint to JobStatus

### DIFF
--- a/src/default_job_handlers/local_shell/__init__.py
+++ b/src/default_job_handlers/local_shell/__init__.py
@@ -40,13 +40,13 @@ class JobHandler(JobHandlerInterface):
         logger.info(f"ShellJob completed successfully. \n {output}")
         return output
 
-    def remove(self) -> str:
+    def remove(self) -> Tuple[JobStatus, str]:
         """Terminate and cleanup all job related resources"""
         try:
             os.remove("./script.sh")
         except FileNotFoundError:
             pass
-        return "Local shell job removed"
+        return JobStatus.REMOVED, "Local shell job removed"
 
     def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""

--- a/src/default_job_handlers/recurring_job/__init__.py
+++ b/src/default_job_handlers/recurring_job/__init__.py
@@ -39,9 +39,9 @@ class JobHandler(JobHandlerInterface):
         self.job.append_log(msg)
         return msg
 
-    def remove(self) -> str:
+    def remove(self) -> Tuple[JobStatus, str]:
         """Terminate and cleanup all job related resources"""
-        return "OK. Nothing to clean up"
+        return JobStatus.REMOVED, "OK. Nothing to clean up"
 
     def result(self) -> Tuple[str, bytes]:
         raise NotImplementedError

--- a/src/default_job_handlers/shell_script/__init__.py
+++ b/src/default_job_handlers/shell_script/__init__.py
@@ -39,13 +39,13 @@ class JobHandler(JobHandlerInterface):
         logger.info(f"ShellJob completed successfully. \n {output}")
         return output
 
-    def remove(self) -> str:
+    def remove(self) -> Tuple[JobStatus, str]:
         """Terminate and cleanup all job related resources"""
         try:
             os.remove("./script.sh")
         except FileNotFoundError:
             pass
-        return "Local shell job removed"
+        return JobStatus.REMOVED, "Local shell job removed"
 
     def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
         """Poll progress from the job instance"""

--- a/src/job_handler_plugins/local_container/__init__.py
+++ b/src/job_handler_plugins/local_container/__init__.py
@@ -59,7 +59,7 @@ class JobHandler(JobHandlerInterface):
         message = "*** Local container job started successfully ***"
         return message
 
-    def remove(self) -> Tuple[str, str]:
+    def remove(self) -> Tuple[JobStatus, str]:
         try:
             container = self.client.containers.get(self.local_container_name)
             if container.status != "exited":

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -50,7 +50,7 @@ class JobHandler(JobHandlerInterface):
         self.job.state = {"job_name": result.json()["name"]}
         return result.status_code  # type: ignore
 
-    def remove(self) -> Tuple[str, str]:
+    def remove(self) -> Tuple[JobStatus, str]:
         result = requests.delete(
             f"{_get_job_url(self.job)}/{self.job.state['job_name']}",
             timeout=10,

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -79,7 +79,7 @@ class JobHandlerInterface(ABC):
     def start(self) -> str:
         """Run or deploy a job or job service"""
 
-    def remove(self) -> str:
+    def remove(self) -> Tuple[JobStatus, str]:
         """Terminate and cleanup all job related resources"""
         raise NotImplementedError
 


### PR DESCRIPTION
## What does this pull request change?
Make remove endpoint return status as JobStatus instead of string

## Why is this pull request needed?
Consistency with job handler interface

## Issues related to this change

