### PR TITLE
fix: update job on status change

### DIFF
--- a/src/job_handler_plugins/reverse_description/__init__.py
+++ b/src/job_handler_plugins/reverse_description/__init__.py
@@ -34,7 +34,7 @@ class JobHandler(JobHandlerInterface):
         with open(f"{self.results_directory}/{self.job.job_uid}", "w") as result_file:
             result_file.write(result)
         logger.info("ReverseDescription job completed")
-        self.job.status = JobStatus.COMPLETED
+        self.job.set_job_status(JobStatus.COMPLETED)
         self.job.stopped = datetime.now()
         return "OK"
 

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -69,6 +69,14 @@ class Job(BaseModel):
         else:
             self.log = log
 
+    def set_job_status(self, status: JobStatus):
+        if status == self.status:
+            return
+        self.status = status
+        match status:
+            case JobStatus.COMPLETED | JobStatus.FAILED:
+                self.ended = datetime.now().replace(microsecond=0)
+
 
 class JobHandlerInterface(ABC):
     def __init__(self, job: Job, data_source: str):


### PR DESCRIPTION
## What does this pull request change?
updates the "ended" field of the job when the status is updated to "completed" or "failed"

## Why is this pull request needed?
"ended" is currently not populated by the job-api

## Issues related to this change
Closes #140 
