### PR TITLE
fix: recurring job pass PAT to new job

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,6 +6,5 @@ services:
       target: development
     image: job-api-development
     environment:
-      API_DEBUG: 1
-      API_ENV: testing
       ENVIRONMENT: local
+      AUTH_ENABLED: 0

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,7 +13,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock # Needed for docker-in-docker jobs
       # - ../data-modelling-storage-service/gen/dmss_api:/dmss_api
     environment:
-      API_DEBUG: 1
       ENVIRONMENT: local
 #      AZURE_JOB_SUBSCRIPTION: 14d57366-b2ae-4da8-8b75-e273c6fdabe2
 #      AZURE_JOB_RESOURCE_GROUP: dmt-test-containers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   dmss:
-    image: datamodelingtool.azurecr.io/dmss:v1.8.1
+    image: datamodelingtool.azurecr.io/dmss:v1.15.1
     restart: unless-stopped
     environment:
       ENVIRONMENT: local

--- a/src/config.py
+++ b/src/config.py
@@ -3,8 +3,8 @@ import os
 
 class Config:
     LOGGER_LEVEL = os.getenv("LOGGING_LEVEL", "INFO")
-    API_DEBUG = os.getenv("API_DEBUG", 0)
     ENVIRONMENT = os.getenv("ENVIRONMENT", "local")
+    AUTH_ENABLED = bool(int(os.getenv("AUTH_ENABLED", "1")))
     DMSS_API = os.getenv("DMSS_API", "http://dmss:5000")
     JOB_API_URL = os.getenv("JOB_API_URL", "http://job-api:5000")
 

--- a/src/default_job_handlers/recurring_job/__init__.py
+++ b/src/default_job_handlers/recurring_job/__init__.py
@@ -21,7 +21,6 @@ class JobHandler(JobHandlerInterface):
         data_source: str,
     ):
         super().__init__(job, data_source)
-        self.headers = {"Access-Key": job.token or ""}
 
     def start(self) -> str:
         msg = f'Starting scheduled job from "{self.job.dmss_id}"'
@@ -32,7 +31,7 @@ class JobHandler(JobHandlerInterface):
         # TODO: Update DMSS to return complete address, and avoid this ugly stuff
         complete_new_job_address = self.job.dmss_id.split("$", 1)[0] + "$" + new_job_address["uid"]
 
-        new_uid, new_log, status = register_job(complete_new_job_address)
+        new_uid, new_log, status = register_job(complete_new_job_address, self.job.token)
 
         msg = f'Job: "{new_uid}", Status: "{status}"'
         logger.info(msg)

--- a/src/dmss_api/rest.py
+++ b/src/dmss_api/rest.py
@@ -207,7 +207,7 @@ class RESTClientObject(object):
             r = RESTResponse(r)
 
             # log response body
-            logger.debug("response body: %s", r.data)
+            #logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
             if r.status == 401:

--- a/src/services/dmss.py
+++ b/src/services/dmss.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from config import Config
+from config import Config, config
 from dmss_api.apis import DefaultApi
 from middleware.store_headers import get_access_key_header, get_auth_header
 
@@ -12,19 +12,23 @@ dmss_api.api_client.configuration.host = Config.DMSS_API
 
 def get_access_token() -> str:
     auth_header = get_auth_header()
+    if config.AUTH_ENABLED and not auth_header:
+        raise ValueError(
+            "Unable to get access token as no authentication headers are available. Are you sure the operation happening in the context of a HTTP request?"
+        )
     if auth_header:
         head_split = auth_header.split(" ")
         if head_split[0].lower() == "bearer" and len(head_split) == 2:
             return head_split[1]  # type: ignore
         raise ValueError("Authorization header malformed. Should be; 'Bearer myAccessTokenString'")
-    else:
-        return ""
+
+    return ""  # This makes sense only when running without authentication
 
 
 def get_document(reference: str, depth: int = 0, token: str | None = None) -> dict:
     # The generated API package was transforming data types. i.e. parsing datetime from strings...
 
-    headers = {"Authorization": f"Bearer {token or get_access_token()}", "Access-Key": token or get_access_token()}
+    headers = {"Authorization": f"Bearer {token or get_access_token()}", "Access-Key": token or ""}
     params = {"depth": depth}
     req = requests.get(f"{Config.DMSS_API}/api/documents/{reference}", params=params, headers=headers, timeout=10)
     req.raise_for_status()
@@ -33,7 +37,7 @@ def get_document(reference: str, depth: int = 0, token: str | None = None) -> di
 
 
 def update_document(reference: str, document_json: str, token: str | None = None) -> dict:
-    headers = {"Authorization": f"Bearer {token or get_access_token()}", "Access-Key": token or get_access_token()}
+    headers = {"Authorization": f"Bearer {token or get_access_token()}", "Access-Key": token or ""}
     req = requests.put(
         f"{Config.DMSS_API}/api/documents/{reference}",
         data={"data": document_json},
@@ -45,7 +49,7 @@ def update_document(reference: str, document_json: str, token: str | None = None
 
 
 def add_document(reference: str, document: dict, token: str | None = None) -> dict:
-    headers = {"Authorization": f"Bearer {token or get_access_token()}", "Access-Key": token or get_access_token()}
+    headers = {"Authorization": f"Bearer {token or get_access_token()}", "Access-Key": token or ""}
     # form_data = {k: json.dumps(v) if isinstance(v, dict) else str(v) for k, v in document.items()}
     req = requests.post(
         f"{Config.DMSS_API}/api/documents/{reference}",
@@ -67,10 +71,14 @@ def get_blueprint(type_ref: str) -> dict:
 
 def get_personal_access_token() -> str:
     """
-    Fetches a long lived Access Token
+    Fetches a long-lived Access Token
     """
     pat_in_header = get_access_key_header()
     if pat_in_header:
+        if not len(pat_in_header) > 0:
+            raise ValueError("Invalid PAT length")
         return pat_in_header  # type: ignore
     dmss_api.api_client.default_headers["Authorization"] = "Bearer " + get_access_token()
-    return dmss_api.token_create()  # type: ignore
+    if new_pat := dmss_api.token_create():
+        return new_pat  # type: ignore
+    raise ValueError("Failed to create new DMSS PAT")

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -109,7 +109,7 @@ class JobHandlerInterface(ABC):
 
 
 def dmss_sync(job: Job) -> Job:
-    fetched: dict = get_document(job.dmss_id)
+    fetched: dict = get_document(job.dmss_id, 0, job.token)
     job_dict = json.loads(job.json())
     merged_kwargs: dict = {
         **fetched,
@@ -118,4 +118,7 @@ def dmss_sync(job: Job) -> Job:
         "stopped": job_dict["stopped"],
         "dmss_id": job.dmss_id,
     }
-    return Job.parse_obj(merged_kwargs)
+    new_job = Job.parse_obj(merged_kwargs)
+    # For some reason, "token" does not survive the exporting and parsing...
+    new_job.token = job.token
+    return new_job


### PR DESCRIPTION
## What does this pull request change?
- Recurring job now passes "token" to the created job
- Fixes a bug where token was lost when dumping pydantic model to json
- Add "AUTH_ENABLED" env var. Raise exception if no token and auth is enabled.

## Why is this pull request needed?
- Recurring job would fail to start scheduled jobs when auth was enabled in dmss

## Issues related to this change
none

