### PR TITLE
fix: make jobStatus an enum

### DIFF
--- a/app/data/WorkflowDS/Blueprints/Job.json
+++ b/app/data/WorkflowDS/Blueprints/Job.json
@@ -36,7 +36,8 @@
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string",
       "optional": false,
-      "default": "Not registered"
+      "default": "not started",
+      "enumType": "./JobStatus"
     },
     {
       "name": "applicationInput",

--- a/app/data/WorkflowDS/Blueprints/JobStatus.json
+++ b/app/data/WorkflowDS/Blueprints/JobStatus.json
@@ -1,0 +1,25 @@
+{
+  "name": "JobStatus",
+  "type": "CORE:Enum",
+  "description": "String enum for valid job statuses",
+  "values": [
+    "registered",
+    "not started",
+    "starting",
+    "running",
+    "failed",
+    "completed",
+    "removed",
+    "unknown"
+  ],
+  "labels": [
+    "Registered",
+    "Not Started",
+    "Starting",
+    "Running",
+    "Failed",
+    "Completed",
+    "Removed",
+    "Unknown"
+  ]
+}

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,7 @@ class Config:
     OAUTH_AUTH_SCOPE: str | None = os.getenv("OAUTH_AUTH_SCOPE")
 
     RECURRING_JOB = "dmss://WorkflowDS/Blueprints/RecurringJob"
+    JOB = "dmss://WorkflowDS/Blueprints/Job"
 
 
 config = Config()

--- a/src/services/job_handler_interface.py
+++ b/src/services/job_handler_interface.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Tuple
 from uuid import UUID
@@ -74,7 +74,7 @@ class Job(BaseModel):
         self.status = status
         match status:
             case JobStatus.COMPLETED | JobStatus.FAILED:
-                self.ended = datetime.now().replace(microsecond=0)
+                self.ended = datetime.now(timezone.utc).replace(microsecond=0)
 
 
 class JobHandlerInterface(ABC):


### PR DESCRIPTION
## What does this pull request change?
- Make a JobStatus enum, and use it in "Job"
- Fix invalid job statuses
- Make timestamps created in dm-job timezone aware

## Why is this pull request needed?
- JobStatus is treated like an enum, and should be one
