### PR TITLE
fix: pretty format started timestamp

### DIFF
--- a/src/services/job_service.py
+++ b/src/services/job_service.py
@@ -149,7 +149,7 @@ def _run_job(job_uid: UUID) -> str:
     message: list[str] | str = ""
     try:
         job_handler = _get_job_handler(job)
-        job.started = datetime.now(timezone.utc).replace(microsecond=0)
+        job.started = datetime.now(timezone.utc).replace(microsecond=0).ctime()
         try:
             message = job_handler.start()
 


### PR DESCRIPTION
A prettier format for jobs started time.
```python
>>> str(datetime.now(timezone.utc).replace(microsecond=0).ctime())
'Fri Jan 19 08:51:36 2024'

```