### PR TITLE
fix: next schedule run message

### DIFF
--- a/src/services/job_service.py
+++ b/src/services/job_service.py
@@ -72,10 +72,9 @@ def schedule_cron_job(job_scheduler: BackgroundScheduler, function: Callable, jo
             replace_existing=True,
             jobstore="redis_job_store",
         )
-        return (
-            "Cron job successfully registered. Next scheduled run "
-            + f"at {scheduled_job.next_run_time - datetime.now(timezone.utc) + datetime.fromisoformat(job.schedule['startDate'])} {scheduled_job.next_run_time.tzinfo}"
-        )
+        if datetime.fromisoformat(job.schedule["startDate"]) > datetime.now(timezone.utc):
+            return f"Cron job successfully registered. Next run wil be after {datetime.fromisoformat(job.schedule['startDate'])}"
+        return f"Cron job successfully registered. Next scheduled run at {scheduled_job.next_run_time}"
     except ValueError as e:
         raise BadRequestException(message=f"Failed to schedule cron job '{job.job_uid}'.", debug=str(e))
 


### PR DESCRIPTION
## What does this pull request change?
To accurately give next run we need to have a complete understanding of the cron syntax.
Implemented a shortcut instead. 

## Issues related to this change

closes #164 