### PR TITLE
fix: handle redix response with no status

### DIFF
--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -66,7 +66,7 @@ class JobHandler(JobHandlerInterface):
         )
         result.raise_for_status()
         response_json = result.json()
-        match (response_json["status"]):
+        match (response_json.get("status")):
             case "Running":  # noqa
                 return JobStatus.RUNNING, "Job is running", None
             case "Failed":  # noqa
@@ -77,5 +77,7 @@ class JobHandler(JobHandlerInterface):
                 )
             case "Succeeded":  # noqa
                 return JobStatus.COMPLETED, "Radix job completed successfully", 1
+            case None:
+                return JobStatus.STARTING, "Radix job is starting", 1
             case _:
                 return JobStatus.UNKNOWN, "Radix returned an unknown status code", 0


### PR DESCRIPTION
## What does this pull request change?
Status request from radix does not always contain "status".

## Why is this pull request needed?
Fixes this:
![Screenshot_20240220_131929](https://github.com/equinor/dm-job/assets/11062560/90f0147a-094d-4ddb-8d94-adf380084ecf)

closes #178 
