### PR TITLE
Fix/handle radix response no status

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   dmss:
-    image: datamodelingtool.azurecr.io/dmss:v1.18.5
+    image: datamodelingtool.azurecr.io/dmss:v1.23.0
     restart: unless-stopped
     environment:
       ENVIRONMENT: local

--- a/src/default_job_handlers/recurring_job/__init__.py
+++ b/src/default_job_handlers/recurring_job/__init__.py
@@ -45,9 +45,7 @@ class JobHandler(JobHandlerInterface):
         if actual_app_input_address[0] == "~":
             job_template["applicationInput"]["address"] = f"~.{actual_app_input_address}"
         new_job_address = add_document(f"{self.job.dmss_id}.schedule.runs", job_template, self.job.token)
-        # TODO: Update DMSS to return complete address, and avoid this ugly stuff
-        complete_new_job_address = self.job.dmss_id.split("$", 1)[0] + "$" + new_job_address["uid"]
-        new_uid, new_log, status = register_job(complete_new_job_address, self.job.token)
+        new_uid, new_log, status = register_job(new_job_address["uid"], self.job.token)
 
         msg = f'Job: "{new_uid}", Status: "{status}"'
         logger.info(msg)

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -61,6 +61,8 @@ class JobHandler(JobHandlerInterface):
         return JobStatus.REMOVED, "Removed"
 
     def progress(self) -> Tuple[JobStatus, None | list[str] | str, None | float]:
+        if self.job.status == JobStatus.FAILED:
+            return JobStatus.FAILED, self.job.log, None
         if not self.job.state:
             return self.job.status, "Radix job is not running yet.", 0
         result = requests.get(

--- a/src/job_handler_plugins/radix/__init__.py
+++ b/src/job_handler_plugins/radix/__init__.py
@@ -50,6 +50,9 @@ class JobHandler(JobHandlerInterface):
         return str(result.status_code)
 
     def remove(self) -> Tuple[JobStatus, str]:
+        if not self.job.state:
+            return JobStatus.REMOVED, "Removed"
+
         result = requests.delete(
             f"{_get_job_url(self.job)}/{self.job.state['job_name']}",
             timeout=10,

--- a/src/services/job_service.py
+++ b/src/services/job_service.py
@@ -195,6 +195,11 @@ def register_job(dmss_id: str, token: str | None = None) -> Tuple[str, str, JobS
     logger.info(f"Registering job '{dmss_id}'")
     token = token if token else get_personal_access_token()
     job_entity = get_document(dmss_id, 1, token)
+    if not isinstance(job_entity, dict):
+        raise BadRequestException(
+            f"Address '{dmss_id}' does not point to a Job, but an entity of type '{type(job_entity)}'",
+            data=job_entity,
+        )
     if job_entity["type"] not in (config.JOB, config.RECURRING_JOB):
         raise BadRequestException(
             f"Address '{dmss_id}' does not point to a Job, but an entity of type '{job_entity['type']}'",
@@ -323,7 +328,7 @@ def update_progress_from_uid(job_uid: UUID, progress: Progress, overwrite_log: b
     return update_progress(job, progress, overwrite_log, external)
 
 
-def update_progress(job: Job, progress: Progress, overwrite_log: bool, external: bool = False) -> dict:
+def update_progress(job: Job, progress: Progress, overwrite_log: bool = False, external: bool = False) -> dict:
     job.external_progress = external or job.external_progress
     if progress.percentage is not None:
         job.percentage = progress.percentage

--- a/src/tests/integration/test_recurring_job.py
+++ b/src/tests/integration/test_recurring_job.py
@@ -48,7 +48,7 @@ class TestRecurringJob(unittest.TestCase):
     def test_starting_and_get_result(self):
         add_document("dmss://WorkflowDS/TestEntities", application_input)
         job_document_dmss_id = add_document("dmss://WorkflowDS/TestEntities", test_job)
-        recurring_job_address = f"dmss://WorkflowDS/${job_document_dmss_id['uid']}"
+        recurring_job_address = job_document_dmss_id["uid"]
         start_job_response = test_client.post("/" + recurring_job_address)
         start_job_response.raise_for_status()
         sleep(100)

--- a/src/tests/integration/test_reverse_job.py
+++ b/src/tests/integration/test_reverse_job.py
@@ -33,7 +33,7 @@ class TestReverseDescription(unittest.TestCase):
     def test_starting_and_get_result(self):
         add_document("dmss://WorkflowDS/TestEntities", application_input)
         job_document_dmss_id = add_document("dmss://WorkflowDS/TestEntities", test_job)
-        start_job_response = test_client.post(f"WorkflowDS/${job_document_dmss_id['uid']}")
+        start_job_response = test_client.post("/" + job_document_dmss_id["uid"])
         start_job_response.raise_for_status()
         sleep(8)  # Let the job run...
         get_results_response = test_client.get(f"/{start_job_response.json()['uid']}/result")


### PR DESCRIPTION
## What does this pull request change?
- fix: fetching progress from a radix job with no status failes
- fix: failing to remove a radix job that never started on radix 
- fix: If a job fails to start, log the error 
- fix: no need for address manipulation when creating scheduled jobs 


depends on https://github.com/equinor/data-modelling-storage-service/pull/807

