### PR TITLE
fix: allow for ssl for redis

### DIFF
--- a/src/services/job_scheduler.py
+++ b/src/services/job_scheduler.py
@@ -5,10 +5,11 @@ from config import config
 
 jobstores = {
     "redis_job_store": RedisJobStore(
-        db=0,
+        db=6,  # DMSS is using 0-3
         host=config.SCHEDULER_REDIS_HOST,
         port=config.SCHEDULER_REDIS_PORT,
         password=config.SCHEDULER_REDIS_PASSWORD,
+        ssl=config.SCHEDULER_REDIS_SSL,
     )
 }
 

--- a/src/services/job_service.py
+++ b/src/services/job_service.py
@@ -39,7 +39,7 @@ def get_job_store():
     return redis.Redis(
         host=config.SCHEDULER_REDIS_HOST,
         port=config.SCHEDULER_REDIS_PORT,
-        db=0,
+        db=5,  # DMSS is using 0-3
         password=config.SCHEDULER_REDIS_PASSWORD,
         ssl=config.SCHEDULER_REDIS_SSL,
         socket_timeout=5,


### PR DESCRIPTION


## Why is this pull request needed?
- Need to be able to configure SSL to use redis in Azure
- Also, dont use the same databases for different things

